### PR TITLE
Update Cipher runtime to 46

### DIFF
--- a/com.github.arshubham.cipher.json
+++ b/com.github.arshubham.cipher.json
@@ -26,6 +26,10 @@
                     "type" : "patch",
                     "path" : "fix-appdata.patch"
                 }
+            ],
+            "post-install" : [
+                "mkdir -p /app/share/icons/hicolor/scalable/apps && mv /app/share/icons/hicolor/128x128/@2/apps/${FLATPAK_ID}.svg /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg",
+                "find /app/share/icons/hicolor -type f -not -path \"*scalable*\" -not -path \"*actions*\" -name \"*.svg\" -delete"
             ]
         }
     ]

--- a/com.github.arshubham.cipher.json
+++ b/com.github.arshubham.cipher.json
@@ -1,9 +1,9 @@
 {
     "app-id": "com.github.arshubham.cipher",
     "runtime": "org.gnome.Platform",
-    "runtime-version" : "44",
+    "runtime-version" : "46",
     "base" : "io.elementary.BaseApp",
-    "base-version" : "juno-22.08",
+    "base-version" : "juno-23.08",
     "sdk": "org.gnome.Sdk",
     "command": "com.github.arshubham.cipher",
     "finish-args": [
@@ -20,7 +20,7 @@
                 {
                     "type" : "git",
                     "url" : "https://github.com/arshubham/cipher.git",
-                    "commit" : "43500400d7a90c00c2237a3133a7209f39ca1e99"
+                    "commit" : "bb45279428e8a5417309b5311f0fa09e0aa519d2"
                 }
             ]
         }

--- a/com.github.arshubham.cipher.json
+++ b/com.github.arshubham.cipher.json
@@ -21,6 +21,10 @@
                     "type" : "git",
                     "url" : "https://github.com/arshubham/cipher.git",
                     "commit" : "bb45279428e8a5417309b5311f0fa09e0aa519d2"
+                },
+                {
+                    "type" : "patch",
+                    "path" : "fix-appdata.patch"
                 }
             ]
         }

--- a/fix-appdata.patch
+++ b/fix-appdata.patch
@@ -1,0 +1,57 @@
+From b08fbb4f0560b9638314608316c48cb7f5e3297b Mon Sep 17 00:00:00 2001
+From: Sabri Ünal <yakushabb@gmail.com>
+Date: Mon, 5 Aug 2024 02:03:13 +0300
+Subject: [PATCH] Fix appdata papercuts
+
+---
+ data/com.github.arshubham.cipher.appdata.xml.in |  9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/data/com.github.arshubham.cipher.appdata.xml.in b/data/com.github.arshubham.cipher.appdata.xml.in
+index c5788d6..54c5b85 100644
+--- a/data/com.github.arshubham.cipher.appdata.xml.in
++++ b/data/com.github.arshubham.cipher.appdata.xml.in
+@@ -10,6 +10,7 @@
+   <provides>
+     <binary>com.github.arshubham.cipher</binary>
+   </provides>
++  <launchable type="desktop-id">com.github.arshubham.cipher.desktop</launchable>
+   <screenshots>
+     <screenshot type="default">
+       <image>https://raw.githubusercontent.com/arshubham/cipher/master/data/images/Screenshot1.png</image>
+@@ -39,19 +40,21 @@
+     </release>
+     <release version="2.0.0" date="2019-09-15">
+       <description>
++        <p>In this version</p>
+         <ul>
+-          <li> New Icon! Thanks @Fatih20 (https://github.com/Fatih20) </li>
++          <li> New Icon! Thanks @Fatih20 (github.com/Fatih20) </li>
+           <li> Added Vigenere Cipher </li>
+           <li> Added SHA384 and SHA512 Hash Functions </li>
+         </ul>
+       </description>
+     </release>
+     <release version="1.0.0" date="2019-02-02">
+       <description>
++        <p>In this version</p>
+         <ul>
+           <li> Complete UI/UX Redesign! </li>
+           <li> Added i18n Capability </li>
+-          <li> Added French Tranlations. Thanks @NathanBnm (https://github.com/NathanBnm) </li>
++          <li> Added French Tranlations. Thanks @NathanBnm (github.com/NathanBnm) </li>
+         </ul>
+       </description>
+     </release>
+@@ -80,7 +83,7 @@
+   <description>
+     <p>A simple application for encoding and decoding text. Hide your text from prying eyes!</p>
+     <p>
+-      <b>Note:</b> This application does not actually encrypt files. This was made just to encipher strings. Have fun!</p>    
++      <em>Note:</em> This application does not actually encrypt files. This was made just to encipher strings. Have fun!</p>
+     <p>Available Ciphers</p>
+     <ul>
+       <li>Caesar Shift Cipher</li>
+--
+libgit2 1.7.2
+


### PR DESCRIPTION
- Update Cipher runtime to 46 since runtime version 44 has reached end-of-life.
- Fix appdata papercuts